### PR TITLE
70 Fix: PHPUnit warnings

### DIFF
--- a/classes/renderables/wrapper.php
+++ b/classes/renderables/wrapper.php
@@ -29,4 +29,5 @@ class wrapper implements \renderable {
     public $url;
     public $canviewfeedback;
     public $isimage;
+    public $candownload;
 }

--- a/tests/jwthelper_test.php
+++ b/tests/jwthelper_test.php
@@ -56,12 +56,12 @@ class jwthelper_test extends \advanced_testcase {
 
         $payload = \Firebase\JWT\JWT::decode($token, new Key($secret, 'HS256'));
 
-        $this->assertObjectHasAttribute('return_url', $payload);
-        $this->assertObjectHasAttribute('iat', $payload);
-        $this->assertObjectHasAttribute('user_id', $payload);
-        $this->assertObjectHasAttribute('course_id', $payload);
-        $this->assertObjectHasAttribute('locale', $payload);
-        $this->assertObjectHasAttribute('roles', $payload);
+        $this->assertObjectHasProperty('return_url', $payload);
+        $this->assertObjectHasProperty('iat', $payload);
+        $this->assertObjectHasProperty('user_id', $payload);
+        $this->assertObjectHasProperty('course_id', $payload);
+        $this->assertObjectHasProperty('locale', $payload);
+        $this->assertObjectHasProperty('roles', $payload);
 
         $this->assertSame($payload->return_url, $CFG->wwwroot);
         if ($userid != null) {


### PR DESCRIPTION
Fix warnings during PHPUnit tests:

  1. Deprecated: Creation of dynamic property filter_ally\renderables\wrapper::$candownload is deprecated in .../filter/ally/tests/filter_test.php on line 870
  2. assertObjectHasAttribute() is deprecated and will be removed in PHPUnit 10. Refactor your test to use assertObjectHasProperty() instead.